### PR TITLE
Reduce .scss-lint property sort order severity

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -104,7 +104,7 @@ linters:
 
     PropertySortOrder:
         enabled: true
-        severity: error
+        severity: warning
 
     PropertySpelling:
         enabled: true


### PR DESCRIPTION
In general, properties should be alphabetically ordered, but there are some cases where non-alpha makes for easier readability (e.g. blocks of `var()` declarations).