### PR TITLE
Add column utils

### DIFF
--- a/src/assets/styles/core.css
+++ b/src/assets/styles/core.css
@@ -26,6 +26,7 @@
 
 @import "./utils/core-colors.css";
 @import "./utils/core-display.css";
+@import "./utils/core-column.css";
 @import "./utils/core-link.css";
 @import "./utils/core-text.css";
 @import "./utils/core-typography.css";

--- a/src/assets/styles/utils/core-column.css
+++ b/src/assets/styles/utils/core-column.css
@@ -1,0 +1,10 @@
+/* Column utilities
+    ========================================================================== */
+
+.u-columnCount2 {
+    column-count: 2;
+}
+
+.u-columnCount3 {
+    column-count: 3;
+}


### PR DESCRIPTION
Support: http://caniuse.com/#feat=multicolumn

We don't need IE8 or IE9 support, or the `break-before`, `break-after`, and `break-inside` properties.

We don't need prefixed versions because we're using Autoprefixer.

Add to the parent element containing nodes: should display nodes in columnar fashion. e.g. 

```html
<ul class="u-columnCount2">
    <li ng-repeat="item in section.items">
        {{ item.label }}
    </li>
</ul>
```
