### PR TITLE
use #master for ui components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
       "rb-table": "~1.1.1",
-      "rbx-ui-components": "rockabox/rbx_ui_components#~1.0.0"
+      "rbx-ui-components": "rockabox/rbx_ui_components#master"
     },
   "resolutions": {
     "angular": "~1.3.11"


### PR DESCRIPTION
This is because:
    1. We are only working on one product
    2. Creative toolkit is not using UI components
    3. No real users so breaking changes fine
    4. It slows us down

We can re-evaluate when needed.

See https://github.com/rockabox/rbx_campaign_management/pull/118