### PR TITLE
Remove default link style

### DIFF
--- a/src/assets/styles/boot/typography.css
+++ b/src/assets/styles/boot/typography.css
@@ -52,18 +52,3 @@ h5,
 h6 {
     font-size: var(--font-size);
 }
-
-/* Inline elements
-   ========================================================================== */
-
-/**
- * Standard link
- */
-
-a {
-    color: var(--color-base-link-default);
-}
-
-a:hover {
-    color: var(--color-base-link-hover);
-}


### PR DESCRIPTION
Should be set explicitly for each component if non-standard or use existing link utility class if standard.